### PR TITLE
update image order in expense

### DIFF
--- a/assets/controllers/photo_gallery_controller.js
+++ b/assets/controllers/photo_gallery_controller.js
@@ -1,0 +1,45 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static values = { pageSize: { type: Number, default: 12 } };
+    static targets = ['item', 'prev', 'next', 'info'];
+
+    #page = 1;
+
+    connect() {
+        this.#render();
+    }
+
+    prev() {
+        if (this.#page > 1) {
+            this.#page--;
+            this.#render();
+        }
+    }
+
+    next() {
+        if (this.#page < this.#totalPages()) {
+            this.#page++;
+            this.#render();
+        }
+    }
+
+    #totalPages() {
+        return Math.ceil(this.itemTargets.length / this.pageSizeValue);
+    }
+
+    #render() {
+        const start = (this.#page - 1) * this.pageSizeValue;
+        const end = start + this.pageSizeValue;
+
+        this.itemTargets.forEach((item, i) => {
+            item.hidden = i < start || i >= end;
+        });
+
+        if (this.hasPrevTarget) this.prevTarget.disabled = this.#page === 1;
+        if (this.hasNextTarget) this.nextTarget.disabled = this.#page === this.#totalPages();
+        if (this.hasInfoTarget) {
+            this.infoTarget.textContent = `Page ${this.#page} / ${this.#totalPages()}`;
+        }
+    }
+}

--- a/assets/styles/_splitter.scss
+++ b/assets/styles/_splitter.scss
@@ -206,6 +206,21 @@
       }
     }
 
+    .photo-pagination {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 1rem;
+      margin-top: 1rem;
+
+      .photo-pagination-info {
+        font-size: 0.85rem;
+        color: var(--color-text-muted, #888);
+        min-width: 80px;
+        text-align: center;
+      }
+    }
+
     .splitter-members {
       color: var(--color-accent);
       font-size: 0.97rem;

--- a/src/Service/SplitterExpenseAggregator.php
+++ b/src/Service/SplitterExpenseAggregator.php
@@ -12,6 +12,7 @@ class SplitterExpenseAggregator
      * - regroupement par date
      * - total par membre payeur
      *
+     * @SuppressWarnings("PHPMD.ShortVariable")
      * @param Splitter $splitter
      * @return array [groupTotal, expensesByDate, memberTotals]
      */
@@ -43,6 +44,8 @@ class SplitterExpenseAggregator
         }
 
         krsort($expensesByDate);
+
+        usort($expensesWithPicture, static fn ($a, $b) => $b->getMadeAt() <=> $a->getMadeAt());
 
         return [
             'groupTotal' => $groupTotal,

--- a/templates/splitter/show.html.twig
+++ b/templates/splitter/show.html.twig
@@ -515,22 +515,43 @@
                             <p class="mt-3">Aucune photo pour ce groupe.</p>
                         </div>
                     {% else %}
-                        <div class="photo-gallery">
-                            {% for expense in expensesWithPicture %}
-                                <div class="photo-item"
-                                     data-bs-toggle="modal"
-                                     data-bs-target="#photoModal{{ expense.id }}">
-                                    <img
-                                        src="{{ vich_uploader_asset(expense, 'pictureFile') }}"
-                                        alt="Photo — {{ expense.name }}"
-                                        loading="lazy"
-                                    >
-                                    <div class="photo-overlay">
-                                        <span class="photo-name">{{ expense.name }}</span>
-                                        <span class="photo-amount">{{ expense.amount }}{{ expense.devise }}</span>
+                        <div
+                            {{ stimulus_controller('photo-gallery', {pageSize: 12}) }}
+                        >
+                            <div class="photo-gallery">
+                                {% for expense in expensesWithPicture %}
+                                    <div class="photo-item"
+                                         {{ stimulus_target('photo-gallery', 'item') }}
+                                         data-bs-toggle="modal"
+                                         data-bs-target="#photoModal{{ expense.id }}">
+                                        <img
+                                            src="{{ vich_uploader_asset(expense, 'pictureFile') }}"
+                                            alt="Photo — {{ expense.name }}"
+                                            loading="lazy"
+                                        >
+                                        <div class="photo-overlay">
+                                            <span class="photo-name">{{ expense.name }}</span>
+                                            <span class="photo-amount">{{ expense.amount }}{{ expense.devise }}</span>
+                                        </div>
                                     </div>
+                                {% endfor %}
+                            </div>
+
+                            {% if expensesWithPicture|length > 12 %}
+                                <div class="photo-pagination">
+                                    <button class="btn btn-sm btn-outline-secondary"
+                                            {{ stimulus_target('photo-gallery', 'prev') }}
+                                            {{ stimulus_action('photo-gallery', 'prev') }}>
+                                        <twig:ux:icon name="ep:arrow-left" height="16" width="16"/>
+                                    </button>
+                                    <span {{ stimulus_target('photo-gallery', 'info') }} class="photo-pagination-info"></span>
+                                    <button class="btn btn-sm btn-outline-secondary"
+                                            {{ stimulus_target('photo-gallery', 'next') }}
+                                            {{ stimulus_action('photo-gallery', 'next') }}>
+                                        <twig:ux:icon name="ep:arrow-right" height="16" width="16"/>
+                                    </button>
                                 </div>
-                            {% endfor %}
+                            {% endif %}
                         </div>
 
                         {% for expense in expensesWithPicture %}


### PR DESCRIPTION
This pull request introduces a paginated photo gallery to the group expenses page, improving usability and performance when displaying a large number of expense photos. The main changes include adding a new Stimulus controller for pagination, updating the Twig template to use this controller and display navigation controls, and enhancing the UI with new styles.

**Photo gallery pagination:**
- Added a new `photo_gallery_controller.js` Stimulus controller that handles pagination logic, navigation, and page info display for photo galleries.
- Updated the group expenses Twig template (`show.html.twig`) to wrap the photo gallery with the new controller, mark photo items as targets, and render pagination controls (previous/next buttons and page info) when there are more than 12 photos. [[1]](diffhunk://#diff-9256fc9b37fc9abf3888c01068de6b10766a414744c4d6555e50642144dade19R518-R524) [[2]](diffhunk://#diff-9256fc9b37fc9abf3888c01068de6b10766a414744c4d6555e50642144dade19R540-R556)

**UI improvements:**
- Added new SCSS styles for the `.photo-pagination` container and its elements to ensure the pagination controls are visually integrated and accessible.

**Data handling:**
- Ensured that `expensesWithPicture` is sorted by date in descending order for consistent display in the gallery.

**Code quality:**
- Added a PHPMD suppression for short variable names in the `SplitterExpenseAggregator` service for clarity and code style consistency.